### PR TITLE
Efficient threading use.

### DIFF
--- a/app/src/main/java/com/kataysantos/movementstopwatch/StopWatchLoop.java
+++ b/app/src/main/java/com/kataysantos/movementstopwatch/StopWatchLoop.java
@@ -1,0 +1,36 @@
+package com.kataysantos.movementstopwatch;
+
+/**
+ * Created by gubatron on 2/5/17.
+ */
+
+public class StopWatchLoop implements Runnable {
+    private final static long SLEEP_TIME = 75;
+    private final StopWatch stopWatch;
+    private final MainActivity mainActivity;
+    private boolean running;
+
+    StopWatchLoop(MainActivity mainActivity, StopWatch stopWatch) {
+        this.mainActivity = mainActivity;
+        this.stopWatch = stopWatch;
+        this.running = true;
+    }
+
+    @Override
+    public void run() {
+        while (running) {
+            try {
+                Thread.sleep(SLEEP_TIME);
+                if (!stopWatch.isPaused()) {
+                    mainActivity.updateOnTime(stopWatch.getTime());
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void stop() {
+        running = false;
+    }
+}

--- a/app/src/main/java/com/kataysantos/movementstopwatch/StopWatchLoopController.java
+++ b/app/src/main/java/com/kataysantos/movementstopwatch/StopWatchLoopController.java
@@ -1,0 +1,10 @@
+package com.kataysantos.movementstopwatch;
+
+/**
+ * Created by gubatron on 2/5/17.
+ */
+
+public interface StopWatchLoopController {
+    void startStopWatchLoop();
+    void stopStopWatchLoop();
+}


### PR DESCRIPTION
When the clock isn't running, the thread that fetches the current time and posts to the UI is ended by setting a boolean flag called `running` to false. I added a new `stop()` method in the `StopWatchLoop` class to do this from the buttons.

I also formalized how this happens with an interface to control such loop (`StopWatchLoopController`), and `MainActivity` implements its methods to start and stop the loop. Starting the loop means creating a new thread. Stopping the loop, means setting the conditions so that this thread dies naturally.